### PR TITLE
small change to add branch over GFX_NVAPI define in shaders

### DIFF
--- a/samples/test-harness/src/graphics/DDGI_D3D12.cpp
+++ b/samples/test-harness/src/graphics/DDGI_D3D12.cpp
@@ -784,7 +784,9 @@ namespace Graphics
                     resources.rtShaders.rgs.filepath = root + L"shaders/ddgi/ProbeTraceRGS.hlsl";
                     resources.rtShaders.rgs.entryPoint = L"RayGen";
                     resources.rtShaders.rgs.exportName = L"DDGIProbeTraceRGS";
+#if GFX_NVAPI
                     Shaders::AddDefine(resources.rtShaders.rgs, L"GFX_NVAPI", std::to_wstring(1));
+#endif
                     Shaders::AddDefine(resources.rtShaders.rgs, L"CONSTS_REGISTER", L"b0");   // for DDGIRootConstants, see Direct3D12.cpp::CreateGlobalRootSignature(...)
                     Shaders::AddDefine(resources.rtShaders.rgs, L"CONSTS_SPACE", L"space1");  // for DDGIRootConstants, see Direct3D12.cpp::CreateGlobalRootSignature(...)
                     Shaders::AddDefine(resources.rtShaders.rgs, L"RTXGI_BINDLESS_TYPE", std::to_wstring(RTXGI_BINDLESS_TYPE));

--- a/samples/test-harness/src/graphics/PathTracing_D3D12.cpp
+++ b/samples/test-harness/src/graphics/PathTracing_D3D12.cpp
@@ -66,7 +66,9 @@ namespace Graphics
                 resources.shaders.rgs.entryPoint = L"RayGen";
                 resources.shaders.rgs.exportName = L"PathTraceRGS";
                 Shaders::AddDefine(resources.shaders.rgs, L"RTXGI_BINDLESS_TYPE", std::to_wstring(RTXGI_BINDLESS_TYPE));
+#if GFX_NVAPI
                 Shaders::AddDefine(resources.shaders.rgs, L"GFX_NVAPI", std::to_wstring(1));
+#endif
                 CHECK(Shaders::Compile(d3d.shaderCompiler, resources.shaders.rgs), "compile path tracing ray generation shader!\n", log);
 
                 // Load and compile the miss shader


### PR DESCRIPTION
I did not define NVAPI during CMake for the samples and I was getting this message:

D3D12 ERROR: ID3D12Device::CreateStateObject: Resource bindings for function "PathTraceRGS" not compatible with associated root signatures (if any): local root signature object: 0x0000000000000000:'(nullptr)', global root signature object: 0x000002C60B81A7E0:'Global Root Signature'. Error detail: Shader UAV descriptor range (BaseShaderRegister=999999, NumDescriptors=1, RegisterSpace=999999) is not fully bound in a root signature. [ STATE_CREATION ERROR #1194: CREATE_STATE_OBJECT_ERROR]

But it is fixed when you add the two ifs so the shader defs don't get defined
