### PR TITLE
ReductionCS.hlsl Fix DDGIExtraReductionCS

### DIFF
--- a/rtxgi-sdk/shaders/ddgi/ReductionCS.hlsl
+++ b/rtxgi-sdk/shaders/ddgi/ReductionCS.hlsl
@@ -398,7 +398,7 @@ void DDGIExtraReductionCS(uint3 GroupID : SV_GroupID, uint3 GroupThreadID : SV_G
     {
         ThreadGroupAverage[waveIndex] = waveTotalValue / waveTotalWeight;
         ThreadGroupWeight[waveIndex] = waveTotalWeight / waveTotalPossibleWeight;
-        InterlockedMax(MaxSumEntry, waveIndex);
+        InterlockedMax(MaxAverageEntry, waveIndex);
     }
 
     GroupMemoryBarrierWithGroupSync();


### PR DESCRIPTION
DDGIExtraReductionCS was outputting the wrong result because using the wrong group shared variable MaxSumEntry instead of MaxAverageEntry, therefore, in the part of the algorithm where it is doing the reduction from the group shared memory failed, since it was not covering all the data.